### PR TITLE
Fix swift KVO when keyPath having a optional value

### DIFF
--- a/stdlib/public/Darwin/Foundation/NSObject.swift
+++ b/stdlib/public/Darwin/Foundation/NSObject.swift
@@ -251,6 +251,23 @@ extension _KeyValueCodingAndObserving {
         }
     }
     
+    /// Overload for keyPath having a optional target value.
+    /// Solve https://bugs.swift.org/browse/SR-6066
+    public func observe<Value>(
+            _ keyPath: KeyPath<Self, Value?>,
+            options: NSKeyValueObservingOptions = [],
+            changeHandler: @escaping (Self, NSKeyValueObservedChange<Value?>) -> Void)
+        -> NSKeyValueObservation {
+        return NSKeyValueObservation(object: self as! NSObject, keyPath: keyPath, options: options) { (obj, change) in
+            let notification = NSKeyValueObservedChange(kind: change.kind,
+                                                        newValue: change.newValue as? Value?,
+                                                        oldValue: change.oldValue as? Value?,
+                                                        indexes: change.indexes,
+                                                        isPrior: change.isPrior)
+            changeHandler(obj as! Self, notification)
+        }
+    }
+    
     public func willChangeValue<Value>(for keyPath: __owned KeyPath<Self, Value>) {
         (self as! NSObject).willChangeValue(forKey: _bridgeKeyPathToString(keyPath))
     }


### PR DESCRIPTION
Fix https://bugs.swift.org/browse/SR-6066.

Fix a long standing issue https://bugs.swift.org/browse/SR-6066.
When keyPath has an optional value, we provide an overloaded method on `_KeyValueCodingAndObserving` to handle the special case.

Resolves [SR-6066](https://bugs.swift.org/browse/SR-6066).
